### PR TITLE
fix: macos 10.15 drag files crash

### DIFF
--- a/DUImageView.m
+++ b/DUImageView.m
@@ -29,10 +29,14 @@
 {
     NSPasteboard *pboard = [sender draggingPasteboard];
     BOOL successful = NO;
-
+    
+    NSPasteboardType type = NSPasteboardTypeFileURL;
+    if (@available(macOS 10.15, *)) {
+        type = NSFilenamesPboardType;
+    }
     if ([[pboard types] containsObject: NSPasteboardTypeFileURL])
     {
-        NSArray *files = [pboard propertyListForType: NSPasteboardTypeFileURL];
+        NSArray *files = [pboard propertyListForType: type];
         [controller startConversion: [files objectAtIndex: 0]];
         successful = NO;
     }

--- a/DUWindow.m
+++ b/DUWindow.m
@@ -29,10 +29,14 @@
 {
     NSPasteboard *pboard = [sender draggingPasteboard];
     BOOL successful = NO;
-
+    
+    NSPasteboardType type = NSPasteboardTypeFileURL;
+    if (@available(macOS 10.15, *)) {
+        type = NSFilenamesPboardType;
+    }
     if ([[pboard types] containsObject: NSPasteboardTypeFileURL])
     {
-        NSArray *files = [pboard propertyListForType: NSPasteboardTypeFileURL];
+        NSArray *files = [pboard propertyListForType: type];
         [controller startConversion: [files objectAtIndex: 0]];
         successful = NO;
     }


### PR DESCRIPTION
Hello,
I have fixed this crash which happened in macOS 10.15, and I have tested several times on my Mac.
