### PR TITLE
Canceling drag n drop dictionary Mac os 10.14.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,18 @@ Download it from [GitHub releases, v2.1](https://github.com/jjgod/mac-dictionary
 
 ## Build instructions
 
-Install static build of glib before trying to build:
+**To prevent flashback when you drag the dictionary to convert in this app**
 
-    brew install glib --with-static
+Download the fixed version
+    https://pan.baidu.com/s/1cLONS1XzKMItgNLswN-mSA pw:rc5q
+    
+    Original: https://zhuanlan.zhihu.com/p/365794977 by 时间与金钱.
+
+1.Install homebrew first
+    /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+    
+2.Install glib
+    brew install glib
 
 ## TODO
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Download it from [GitHub releases, v2.1](https://github.com/jjgod/mac-dictionary
 
 ## Build instructions
 
-**To prevent flashback when you drag the dictionary to convert in this app**
+## To prevent flashback when you drag the dictionary to convert in this app
 
 Download the fixed version
     https://pan.baidu.com/s/1cLONS1XzKMItgNLswN-mSA pw:rc5q


### PR DESCRIPTION
-[__NSCFString objectAtIndex:]: unrecognized selector sent to instance 0x600000f0a800
*** Canceling drag because exception 'NSInvalidArgumentException' (reason '-[__NSCFString objectAtIndex:]: unrecognized selector sent to instance 0x600000f0a800') was raised during a dragging session
cert[0]: TemporalValidity =(leaf)[]> 0
cert[2]: AnchorTrusted =(leaf)[force]> 0


this link doesnt work
https://pan.baidu.com/s/1cLONS1XzKMItgNLswN-mSA


Trying to built with xcode 10.2 same thing drag n drop doesnt do nothing!

